### PR TITLE
Fix Todoist::Misc::Items#add_item for passing extra params

### DIFF
--- a/lib/todoist/misc/items.rb
+++ b/lib/todoist/misc/items.rb
@@ -29,7 +29,7 @@ module Todoist
             optional_params.delete("labels")
           end
 
-          params.merge(optional_params)
+          params.merge!(optional_params)
           result = @client.api_helper.get_response(Config::TODOIST_ITEMS_ADD_COMMAND, params)
           item = ParseHelper.make_object(result)
           return item

--- a/spec/misc_items_spec.rb
+++ b/spec/misc_items_spec.rb
@@ -28,6 +28,17 @@ describe Todoist::Misc::Items do
     end
   end
 
+  it "is able to add a priority item" do
+    VCR.use_cassette("misc_items_is_able_to_add_a_priority_item") do
+      item = @client.misc_items.add_item("Test quick add content", priority: 4)
+      expect(item).to be_truthy
+      expect(item.priority).to eq(4)
+      
+      item_data = @client.misc_items.get_item(item)
+      @client.sync_items.delete([item])
+      @client.sync
+    end
+  end
   
 
 end


### PR DESCRIPTION
Hey, thanks for that gem!

**I found this bug:**

Extra params aren't sent when creating a item when using the [misc add_item method](https://developer.todoist.com/sync/v8/#add-item).

**Reason:** 

A variable was expected to be mutated but was not, hence the bug.

Thanks!