### PR TITLE
Fix item and project deletion

### DIFF
--- a/lib/todoist/sync/items.rb
+++ b/lib/todoist/sync/items.rb
@@ -18,10 +18,9 @@ module Todoist
           return @client.api_helper.command(args, "item_update")
         end
 
-        # Delete items given an array of items
-        def delete(items)
-          item_ids = items.collect { |item| item.id }
-          args = {ids: item_ids.to_json}
+        # Delete an item given an item id
+        def delete(item_id)
+          args = {id: item_id}
           return @client.api_helper.command(args, "item_delete")
         end
 

--- a/lib/todoist/sync/projects.rb
+++ b/lib/todoist/sync/projects.rb
@@ -15,10 +15,9 @@ module Todoist
         return @client.api_helper.add(args, "project_add")
       end
 
-      # Delete projects given an array of projects
-      def delete(projects)
-        project_ids = projects.collect { |project| project.id }   
-        args = {ids: project_ids.to_json}
+      # Delete a project given a project id
+      def delete(project_id)
+        args = {id: project_id}
         return @client.api_helper.command(args, "project_delete")
       end
 

--- a/spec/items_spec.rb
+++ b/spec/items_spec.rb
@@ -33,7 +33,7 @@ describe Todoist::Sync::Items do
       items_list =  @client.sync_items.collection
       queried_object = items_list[update_item.id]
       expect(queried_object.priority).to eq(2)
-      @client.sync_items.delete([update_item])
+      @client.sync_items.delete(update_item.id)
       @client.sync
     end
   end
@@ -74,7 +74,8 @@ describe Todoist::Sync::Items do
 
       # Clean up extra item
 
-      @client.sync_items.delete([item, item2])
+      @client.sync_items.delete(item.id)
+      @client.sync_items.delete(item2.id)
       @client.sync
     end
 
@@ -92,8 +93,8 @@ describe Todoist::Sync::Items do
       queried_object = items_list[item.id]
       expect(queried_object.project_id).to eq(project.id)
 
-      @client.sync_projects.delete([project])
-      @client.sync_items.delete([item])
+      @client.sync_projects.delete(project.id)
+      @client.sync_items.delete(item.id)
       @client.sync
     end
   end
@@ -108,7 +109,7 @@ describe Todoist::Sync::Items do
       items_list =  @client.sync_items.collection
       queried_object = items_list[item.id]
       expect(queried_object.checked).to eq(true)
-      @client.sync_items.delete([queried_object])
+      @client.sync_items.delete(queried_object.id)
       @client.sync
     end
   end
@@ -131,7 +132,7 @@ describe Todoist::Sync::Items do
       queried_object = items_list[item.id]
       expect(queried_object.checked).to eq(false)
 
-      @client.sync_items.delete([queried_object])
+      @client.sync_items.delete(queried_object.id)
       @client.sync
     end
   end
@@ -150,7 +151,7 @@ describe Todoist::Sync::Items do
       due_date_new = queried_object.due
       expect(due_date_new).not_to eq(due_date_original)
 
-      @client.sync_items.delete([queried_object])
+      @client.sync_items.delete(queried_object.id)
       @client.sync
     end
   end
@@ -165,7 +166,7 @@ describe Todoist::Sync::Items do
       items_list =  @client.sync_items.collection
       queried_object = items_list[item.id]
       expect(queried_object.checked).to eq(true)
-      @client.sync_items.delete([queried_object])
+      @client.sync_items.delete(queried_object.id)
       @client.sync
     end
   end
@@ -181,9 +182,26 @@ describe Todoist::Sync::Items do
       items_list =  @client.sync_items.collection
       queried_object = items_list[item.id]
       expect(queried_object.day_order).to eq(1000)
-      @client.sync_items.delete([queried_object])
+      @client.sync_items.delete(queried_object.id)
       @client.sync
     end
   end
+
+  it "is able to delete an item" do
+    VCR.use_cassette("items_is_able_to_delete_an_item") do
+      item = @client.sync_items.add({content: "Item-to-be-deleted"})
+      expect(item).to be_truthy
+      items_list =  @client.sync_items.collection
+      queried_object = items_list[item.id]
+      expect(queried_object.content).to eq("Item-to-be-deleted")
+      @client.sync_items.delete(item.id)
+      @client.sync
+
+      items_list =  @client.sync_items.collection
+      queried_object = items_list[item.id]
+      expect(queried_object.is_deleted).to eq(true)
+    end
+  end
+
 
 end

--- a/spec/projects_spec.rb
+++ b/spec/projects_spec.rb
@@ -33,7 +33,7 @@ describe Todoist::Sync::Projects do
       expect(result).to be_truthy
       result = @client.sync_projects.unarchive([project])
       expect(result).to be_truthy
-      @client.sync_projects.delete([project])
+      @client.sync_projects.delete(project.id)
       @client.sync
     end
   end
@@ -46,7 +46,7 @@ describe Todoist::Sync::Projects do
       expect(result).to be_truthy
       queried_object = @client.sync_projects.collection[update_project.id]
       expect(queried_object.name).to eq(update_project.name)
-      @client.sync_projects.delete([update_project])
+      @client.sync_projects.delete(update_project.id)
       @client.sync
     end
   end
@@ -87,12 +87,28 @@ describe Todoist::Sync::Projects do
 
       # Clean up extra project
 
-      @client.sync_projects.delete([project2])
-      @client.sync_projects.delete([project])
+      @client.sync_projects.delete(project2.id)
+      @client.sync_projects.delete(project.id)
       @client.sync
     end
 
 
+  end
+
+  it "is able to delete a project" do
+    VCR.use_cassette("projects_is_able_to_delete_a_project") do
+      project = @client.sync_projects.add({name: "Project-to-be-deleted"})
+      expect(project).to be_truthy
+      projects_list =  @client.sync_projects.collection
+      queried_object = projects_list[project.id]
+      expect(queried_object.name).to eq("Project-to-be-deleted")
+      @client.sync_projects.delete(project.id)
+      @client.sync
+
+      projects_list =  @client.sync_projects.collection
+      queried_object = projects_list[project.id]
+      expect(queried_object.is_deleted).to eq(true)
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,12 +38,12 @@ module Todoist
     	def self.pop_uuid(resource)
         path = "fixtures/uuid/#{@@type}_#{resource}.yml"
         # File does not exist
-        if !File.exists?(path)
+        if !File.exist?(path)
           100.times do
             @@uuids[resource] << SecureRandom.uuid
-          end  
-          File.write(path, @@uuids[resource].to_yaml) 
-        elsif File.exists?(path) && @@uuids[resource].empty?
+          end
+          File.write(path, @@uuids[resource].to_yaml)
+        elsif File.exist?(path) && @@uuids[resource].empty?
           @@uuids[resource] = YAML.load_file(path)
         end	      
         


### PR DESCRIPTION
Regarding switching `File.exists?` to `File.exist?` It has been removed since Ruby 3.2.0 https://bugs.ruby-lang.org/issues/17391 

API docs for deleting an item: https://developer.todoist.com/sync/v9/#delete-item

API docs for deleting a project: https://developer.todoist.com/sync/v9/#delete-a-project

Following the instructions in the README, I was able to run the tests, and did the following:

- Ran all `items_spec.rb` tests, noticed that indeed the created items were not removed
- Write a test to create an item then delete it and assert for it to be marked as deleted
- Test was failing
- Updated the Iterms Sync Service
- Test passed
- Did the same for Projects